### PR TITLE
Replace LGTM with CodeQL

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,18 +24,18 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
           queries: +security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v2
+        uses: github/codeql-action/autobuild@v3
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v3
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,41 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+  schedule:
+    - cron: "8 20 * * 1"
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ python ]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          languages: ${{ matrix.language }}
+          queries: +security-and-quality
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v2
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 [![Python Tests](https://github.com/sopel-irc/sopel-bucket/actions/workflows/python-tests.yml/badge.svg?branch=master)](https://github.com/sopel-irc/sopel-bucket/actions/workflows/python-tests.yml)
 [![PyPI version](https://badge.fury.io/py/sopel-modules.bucket.svg)](https://badge.fury.io/py/sopel-modules.bucket)
-[![Total alerts](https://img.shields.io/lgtm/alerts/g/sopel-irc/sopel-bucket.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/sopel-irc/sopel-bucket/alerts/)
-[![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/sopel-irc/sopel-bucket.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/sopel-irc/sopel-bucket/context:python)
 
 **Maintainer:** [@RustyBower](https://github.com/rustybower)
 


### PR DESCRIPTION
Yoinked the CodeQL workflow file from upstream (main Sopel repo) and tweaked it a bit.

I couldn't find badges equivalent to what LGTM offered for alerts & code grade—only a GHA workflow status badge that would (probably) always say "passing", so I skipped replacing the removed readme badges.